### PR TITLE
    add option: frozen players needs to press twice 'move' keys to dodge

### DIFF
--- a/qcsrc/server/autocvars.qh
+++ b/qcsrc/server/autocvars.qh
@@ -1141,6 +1141,7 @@ float autocvar_sv_dodging_delay;
 float autocvar_sv_dodging_height_threshold;
 float autocvar_sv_dodging_horiz_speed;
 float autocvar_sv_dodging_horiz_speed_frozen;
+float autocvar_sv_dodging_frozen_autorepeat;
 float autocvar_sv_dodging_ramp_time;
 float autocvar_sv_dodging_sound;
 float autocvar_sv_dodging_up_speed;

--- a/qcsrc/server/mutators/mutator_dodging.qc
+++ b/qcsrc/server/mutators/mutator_dodging.qc
@@ -186,6 +186,7 @@ MUTATOR_HOOKFUNCTION(dodging_GetPressedKeys) {
 	float frozen_dodging;
 	float do_nothing = 0;
 	frozen_dodging = (self.frozen && autocvar_sv_dodging_frozen);
+	float frozen_and_autorepeat = frozen_dodging && autocvar_sv_dodging_frozen_autorepeat;
 
 	float dodge_detected;
 	if (g_dodging == 0)
@@ -215,45 +216,45 @@ MUTATOR_HOOKFUNCTION(dodging_GetPressedKeys) {
 
 	if (self.movement_x > 0) {
 		// is this a state change?
-		if (!(self.pressedkeys & KEY_FORWARD) || frozen_dodging) {
+		if (!(self.pressedkeys & KEY_FORWARD) || frozen_and_autorepeat) {
+			tap_direction_x = 1.0;
 			if ((time - self.last_FORWARD_KEY_time) < self.cvar_cl_dodging_timeout)	{ 
-				tap_direction_x = 1.0;
 				dodge_detected = 1;
 			}
- 			self.last_FORWARD_KEY_time = time;
+			self.last_FORWARD_KEY_time = time;
  		}
 	}
 
 	if (self.movement_x < 0) {
 		// is this a state change?
- 		if (!(self.pressedkeys & KEY_BACKWARD) || frozen_dodging) {
+ 		if (!(self.pressedkeys & KEY_BACKWARD) || frozen_and_autorepeat) {
 			tap_direction_x = -1.0;
 			if ((time - self.last_BACKWARD_KEY_time) < self.cvar_cl_dodging_timeout)	{ 
 				dodge_detected = 1;
 			}
- 			self.last_BACKWARD_KEY_time = time;
+			self.last_BACKWARD_KEY_time = time;
  		}
 	}
 
 	if (self.movement_y > 0) {
 		// is this a state change?
-		if (!(self.pressedkeys & KEY_RIGHT) || frozen_dodging) {
+		if (!(self.pressedkeys & KEY_RIGHT) || frozen_and_autorepeat) {
 			tap_direction_y = 1.0;
 			if ((time - self.last_RIGHT_KEY_time) < self.cvar_cl_dodging_timeout)	{ 
 				dodge_detected = 1;
 			}
- 			self.last_RIGHT_KEY_time = time;
+			self.last_RIGHT_KEY_time = time;
  		}
 	}
 
 	if (self.movement_y < 0) {
 		// is this a state change?
-		if (!(self.pressedkeys & KEY_LEFT) || frozen_dodging) {
+		if (!(self.pressedkeys & KEY_LEFT) || frozen_and_autorepeat) {
 			tap_direction_y = -1.0;
 			if ((time - self.last_LEFT_KEY_time) < self.cvar_cl_dodging_timeout)	{ 
 				dodge_detected = 1;
 			}
- 			self.last_LEFT_KEY_time = time;
+			self.last_LEFT_KEY_time = time;
  		}
 	}
 


### PR DESCRIPTION
This is a small option to toggle whether frozen players are able to dodge without typing the movement key twice. It is disabled by default because frozen player could move too freely and it changed the original gameplay where teamplay was more favored. As I wrote this patch I normalized the placement "tap_direction" and "last_time_X" so all "if" blocks looks the same (should be refactorzed by the way).

Extended message:

```
add autocvar: sv_dodging_frozen_autorepeat
uniformize when last_X is set (all the same)
```
