### PR TITLE
Remove recursion in mutator_zombie_apocalypse.qc (too aggressive)

### DIFF
--- a/qcsrc/server/mutators/mutator_zombie_apocalypse.qc
+++ b/qcsrc/server/mutators/mutator_zombie_apocalypse.qc
@@ -6,8 +6,6 @@ void za_SpawnMonster()
 	
 	if(MoveToRandomMapLocation(e, DPCONTENTS_SOLID | DPCONTENTS_CORPSE | DPCONTENTS_PLAYERCLIP, DPCONTENTS_SLIME | DPCONTENTS_LAVA | DPCONTENTS_SKY | DPCONTENTS_BODY | DPCONTENTS_DONOTENTER, Q3SURFACEFLAG_SKY, 10, 1024, 256))
 		mon = spawnmonster(autocvar_g_za_spawnmonster, 0, self, self, e.origin, FALSE, 2);
-	else
-		za_SpawnMonster(); // finding a location failed, retry
 		
 	e.think = SUB_Remove;
 	e.nextthink = time + 0.1;


### PR DESCRIPTION
I had a stack overflow several time with zombie mode enabled, I think this is the cause of my problem. On map where it's hard for zombies to spawn (map made of corridors especially) this may cause problems.

In practise, the removal of the recursion doesn't affect the spawning of monsters at all! It's really negligible in most case.
