### PR TITLE
Fix joining best team

### DIFF
--- a/mod/common/gamemodes/conquest/conquest.qc
+++ b/mod/common/gamemodes/conquest/conquest.qc
@@ -915,6 +915,7 @@ MUTATOR_HOOKFUNCTION(cq, HavocBot_ChooseRole)
 MUTATOR_HOOKFUNCTION(cq, TeamBalance_CheckAllowedTeams)
 {
 	M_ARGV(0, float) = cq_teams;
+	return true;
 }
 
 void cq_ScoreRules(int teams)

--- a/mod/common/gamemodes/jailbreak/jailbreak.qc
+++ b/mod/common/gamemodes/jailbreak/jailbreak.qc
@@ -1355,6 +1355,7 @@ MUTATOR_HOOKFUNCTION(jb, GiveFragsForKill)
 MUTATOR_HOOKFUNCTION(jb, TeamBalance_CheckAllowedTeams)
 {
 	M_ARGV(0, float) = jb_teams;
+	return true;
 }
 
 MUTATOR_HOOKFUNCTION(jb, AllowMobSpawning)

--- a/mod/common/gamemodes/snafu/snafu.qc
+++ b/mod/common/gamemodes/snafu/snafu.qc
@@ -53,6 +53,7 @@ int snafu_teams;
 MUTATOR_HOOKFUNCTION(snafu, TeamBalance_CheckAllowedTeams, CBC_ORDER_EXCLUSIVE)
 {
 	M_ARGV(0, float) = snafu_teams;
+	return true;
 }
 
 MUTATOR_HOOKFUNCTION(snafu, PlayHitsound)

--- a/mod/common/gamemodes/vip/vip.qc
+++ b/mod/common/gamemodes/vip/vip.qc
@@ -468,6 +468,7 @@ MUTATOR_HOOKFUNCTION(vip, OnEntityPreSpawn)
 MUTATOR_HOOKFUNCTION(vip, TeamBalance_CheckAllowedTeams)
 {
 	M_ARGV(0, float) = vip_teams;
+	return true;
 }
 
 vector vip_SoulGemColormod(int theteam, bool iseffect)


### PR DESCRIPTION
Without these changes, the server will crash as soon as a player tries to joint the best team.

Only tested in jb, but the other gamemodes should do the same.