### PR TITLE
Add GitHub action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,41 @@
+name: Build
+on:
+  push:
+
+jobs:
+  build:
+
+    runs-on: ubuntu-20.04
+
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Prepare
+        env:
+          CI: true
+        run: ./update.sh
+
+      - name: Build
+        env:
+          TERM: xterm
+        run: ./build.sh
+
+      - name: Store artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: artifacts
+          path: |
+            compiled/*
+            xonotic/qcsrc/*.pk3
+          if-no-files-found: error
+
+      - name: Publish a release
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          files: |
+            compiled/*
+            xonotic/qcsrc/*.pk3

--- a/update.sh
+++ b/update.sh
@@ -2,7 +2,10 @@
 cd ${0%[\\/]*}
 set -eu
 
-git pull --tags
+git fetch --tags
+if [ -z "${CI-}" ]; then
+    git pull
+fi
 
 git submodule update --init --depth 100
 


### PR DESCRIPTION
This is more as-is version of the Action without quite so much revising the build scripts. I suspect that since the SMB servers are no longer online a lot of what's currently in them is no longer necessary, but better to do things iteratively anyway.

If this is merged, we can then remove Travis and discuss what the build scripts should look like.

A GitHub action will run on every push that builds the modpack and
stores the artifacts. If the push matches a tag, a release will be
opened in the name of the tag and the artifacts published to the
release.