### PR TITLE
Add daily action to test against QC master

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -1,0 +1,29 @@
+name: QC Master Daily
+on:
+  schedule:
+    - cron: '19 0 * * *'
+  workflow_dispatch:
+
+jobs:
+  qc-master-daily:
+
+    runs-on: ubuntu-20.04
+
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Prepare
+        env:
+          CI: true
+        run: ./update.sh
+
+      - name: Checkout xonotic-data master
+        run: |
+          git -C xonotic checkout master
+
+      - name: Build
+        env:
+          TERM: xterm
+        run: ./build.sh


### PR DESCRIPTION
This action will build the modpack against the current xonotic-data
master branch to indicate any new incompatibilities between the two.

This will also make it easier for those (myself included) with patches on
the modpack and/or xonotic-data to determine if compile-time errors are
related to their patches or not.